### PR TITLE
Ruby 2.7.3 support

### DIFF
--- a/zombie_scout.gemspec
+++ b/zombie_scout.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+require 'date'
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'zombie_scout/version'
@@ -24,8 +25,8 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_dependency('parser', '~> 2.1')
-  s.add_dependency('thor', '~> 0.18')
-  s.add_dependency('flog', '~> 4.2')
-  s.add_development_dependency "bundler", "~> 1.10"
+  s.add_dependency('parser')
+  s.add_dependency('thor')
+  s.add_dependency('flog')
+  s.add_development_dependency "bundler"
 end


### PR DESCRIPTION
Hey Dan!

I had a need for Zombie Scout today, and to my delight, it worked on Ruby 2.7.3 without an issue.  The dependencies were just out of date.  They should probably be updated with more granularity than just removing the versions entirely (like I did here), but this worked well enough for me to run Zombie Scout today on Ruby 2.7.3, so I thought I should share.  I was happy to find that there were no breaking changes in the last 5 years.

Hope this helps!